### PR TITLE
Fix error with `yarn purr`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "axios": "^0.27.2",
     "chain-registry": "git+https://github.com/cosmos/chain-registry.git",
     "cosmwasm": "^1.1.1",
-    "cw-croncat": "git+https://github.com/CronCats/cw-croncat.git#714758611e6e8a76720a8f6d41a7f1818ca1fcab",
+    "cw-croncat": "git+https://github.com/CronCats/cw-croncat.git",
     "cw-purrbox": "git+https://github.com/CronCats/cw-purrbox.git",
     "dotenv": "^16.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "axios": "^0.27.2",
     "chain-registry": "git+https://github.com/cosmos/chain-registry.git",
     "cosmwasm": "^1.1.1",
-    "cw-croncat": "git+https://github.com/CronCats/cw-croncat.git#ft/proxy",
+    "cw-croncat": "git+https://github.com/CronCats/cw-croncat.git#714758611e6e8a76720a8f6d41a7f1818ca1fcab",
     "cw-purrbox": "git+https://github.com/CronCats/cw-purrbox.git",
     "dotenv": "^16.0.0"
   }

--- a/tasks.js
+++ b/tasks.js
@@ -64,7 +64,7 @@ async function main() {
   //   pub interval: Interval,
   //   pub boundary: Boundary,
   //   pub stop_on_fail: bool,
-  //   pub action: CosmosMsg,
+  //   pub actions: Vec<Action>,
   //   pub rules: Option<Vec<Rule>>,
   // }
   const tasks = [
@@ -82,7 +82,7 @@ async function main() {
         end: null,
       },
       stop_on_fail: false,
-      action: sampleActions[1],
+      actions: [sampleActions[1]],
       // TODO: setup a rules example too
       rules: [],
     },
@@ -92,7 +92,7 @@ async function main() {
       },
       boundary: { start: null, end: null, },
       stop_on_fail: false,
-      action: sampleActions[2],
+      actions: [sampleActions[2]],
       rules: [],
     },
 
@@ -103,7 +103,7 @@ async function main() {
       },
       boundary: { start: null, end: null, },
       stop_on_fail: false,
-      action: sampleActions[0],
+      actions: [sampleActions[0]],
       // rules: [
       //   {
       //     contract_addr: iftttSimpleContract,
@@ -119,7 +119,7 @@ async function main() {
     //   },
     //   boundary: { start: null, end: null, },
     //   stop_on_fail: true,
-    //   action: sampleActions[0],
+    //   actions: [sampleActions[0]],
     //   rules: [
     //     {
     //       contract_addr: iftttSimpleContract,

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,9 +448,9 @@ cosmwasm@^1.1.1:
     "@cosmjs/stargate" "^0.28.3"
     "@cosmjs/utils" "^0.28.3"
 
-"cw-croncat@git+https://github.com/CronCats/cw-croncat.git#ft/proxy":
+"cw-croncat@git+https://github.com/CronCats/cw-croncat.git#714758611e6e8a76720a8f6d41a7f1818ca1fcab":
   version "0.0.0"
-  resolved "git+https://github.com/CronCats/cw-croncat.git#9ab52cc9ae2930618251b531f874ec4842b1ed4f"
+  resolved "git+https://github.com/CronCats/cw-croncat.git#714758611e6e8a76720a8f6d41a7f1818ca1fcab"
 
 "cw-purrbox@git+https://github.com/CronCats/cw-purrbox.git":
   version "0.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,9 +448,9 @@ cosmwasm@^1.1.1:
     "@cosmjs/stargate" "^0.28.3"
     "@cosmjs/utils" "^0.28.3"
 
-"cw-croncat@git+https://github.com/CronCats/cw-croncat.git#714758611e6e8a76720a8f6d41a7f1818ca1fcab":
+"cw-croncat@git+https://github.com/CronCats/cw-croncat.git":
   version "0.0.0"
-  resolved "git+https://github.com/CronCats/cw-croncat.git#714758611e6e8a76720a8f6d41a7f1818ca1fcab"
+  resolved "git+https://github.com/CronCats/cw-croncat.git#64972490f5868713bfbe527c6d153ccf4a9be4b7"
 
 "cw-purrbox@git+https://github.com/CronCats/cw-purrbox.git":
   version "0.0.0"


### PR DESCRIPTION
Fixes #4 

The error occurred because launch-tools were using the old version of croncat. Changed the dependency so that it points to the main branch.

Also updated `yarn tasks`.